### PR TITLE
fix(commands): fix passing `"false"` to `formatter-enabled`, `linter-enabled`, and `organize-imports-enabled` options

### DIFF
--- a/src/Command/BiomeJsCheckCommand.php
+++ b/src/Command/BiomeJsCheckCommand.php
@@ -53,9 +53,9 @@ final class BiomeJsCheckCommand extends Command
         $process = $this->biomeJs->check(
             apply: $input->getOption('apply'),
             applyUnsafe: $input->getOption('apply-unsafe'),
-            formatterEnabled: $input->getOption('formatter-enabled'),
-            linterEnabled: $input->getOption('linter-enabled'),
-            organizeImportsEnabled: $input->getOption('organize-imports-enabled'),
+            formatterEnabled: filter_var($input->getOption('formatter-enabled'), FILTER_VALIDATE_BOOL),
+            linterEnabled: filter_var($input->getOption('linter-enabled'), FILTER_VALIDATE_BOOL),
+            organizeImportsEnabled: filter_var($input->getOption('organize-imports-enabled'), FILTER_VALIDATE_BOOL),
             staged: $input->getOption('staged'),
             changed: $input->getOption('changed'),
             since: $input->getOption('since'),

--- a/src/Command/BiomeJsCiCommand.php
+++ b/src/Command/BiomeJsCiCommand.php
@@ -49,9 +49,9 @@ final class BiomeJsCiCommand extends Command
         $this->biomeJs->setOutput($this->io);
 
         $process = $this->biomeJs->ci(
-            formatterEnabled: $input->getOption('formatter-enabled'),
-            linterEnabled: $input->getOption('linter-enabled'),
-            organizeImportsEnabled: $input->getOption('organize-imports-enabled'),
+            formatterEnabled: filter_var($input->getOption('formatter-enabled'), FILTER_VALIDATE_BOOL),
+            linterEnabled: filter_var($input->getOption('linter-enabled'), FILTER_VALIDATE_BOOL),
+            organizeImportsEnabled: filter_var($input->getOption('organize-imports-enabled'), FILTER_VALIDATE_BOOL),
             changed: $input->getOption('changed'),
             since: $input->getOption('since'),
             path: $input->getArgument('path'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Close #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.),
this will help people understand your PR.
-->

Fix 
<img width="1718" alt="image" src="https://github.com/Kocal/BiomeJsBundle/assets/2103975/702ce65c-910e-4dd5-9400-5f5a51059108">
