### PR TITLE
fix(services): don't rely on Process::isTtySupported() on services definition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
           cd my_app
           symfony composer config minimum-stability dev
           symfony composer config repositories.biome-js-bundle '{"type":"path", "url":"../","options":{"symlink":true}}'
-          symfony composer require 'kocal/biome-js-bundle:*' --dev
+          symfony composer require 'kocal/biome-js-bundle:*' --dev --no-interaction
           cat << EOF > biome.json
           { 
             "files": {
@@ -139,15 +139,15 @@ jobs:
           EOF
 
       - name: Run Biome CI, which should fails
-        run: symfony console biome:ci .
+        run: symfony console biomejs:ci .
         continue-on-error: true
         working-directory: my_app
 
       - name: Run Biome Check, and apply fixes
-        run: symfony console biome:check . --apply
+        run: symfony console biomejs:check . --apply
         working-directory: my_app
 
       - name: Run Biome CI, which should now pass
-        run: symfony console biome:ci .
+        run: symfony console biomejs:ci .
         working-directory: my_app
 

--- a/config/services.php
+++ b/config/services.php
@@ -2,20 +2,15 @@
 
 use Kocal\BiomeJsBundle\BiomeJs;
 use Kocal\BiomeJsBundle\BiomeJsBinary;
+use Kocal\BiomeJsBundle\BiomeJsBinaryInterface;
 use Kocal\BiomeJsBundle\Command\BiomeJsCheckCommand;
 use Kocal\BiomeJsBundle\Command\BiomeJsCiCommand;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\Process\Process;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
-    $container->parameters()
-        // Internal parameter to enable/disable TTY mode, useful for tests (if someone has a better idea, feel free to suggest it!)
-        ->set('biomejs.use_tty', Process::isTtySupported())
-    ;
-
     $container->services()
         ->set('biomejs.binary', BiomeJsBinary::class)
         ->args([
@@ -23,11 +18,11 @@ return static function (ContainerConfigurator $container): void {
             param('kernel.project_dir').'/var/biomejs',
             abstract_arg('Biome.js binary version'),
         ])
+        ->alias(BiomeJsBinaryInterface::class, 'biomejs.binary')
 
         ->set('biomejs', BiomeJs::class)
         ->args([
             service('biomejs.binary'),
-            param('biomejs.use_tty')
         ])
 
         ->set('biomejs.command.ci', BiomeJsCiCommand::class)

--- a/src/BiomeJs.php
+++ b/src/BiomeJs.php
@@ -12,8 +12,7 @@ final class BiomeJs
     private ?SymfonyStyle $output;
 
     public function __construct(
-        private readonly BiomeJsBinary $biomeJsBinary,
-        private readonly bool $useTty = true,
+        private readonly BiomeJsBinaryInterface $biomeJsBinary,
     ) {
     }
 
@@ -59,7 +58,6 @@ final class BiomeJs
 
         $this->biomeJsBinary->setOutput($this->output);
         $process = $this->biomeJsBinary->createProcess($arguments);
-        $process->setTty($this->useTty);
 
         $this->output?->note('Executing Biome.js "check" (pass -v to see more details).');
         if ($this->output?->isVerbose()) {
@@ -98,7 +96,6 @@ final class BiomeJs
 
         $this->biomeJsBinary->setOutput($this->output);
         $process = $this->biomeJsBinary->createProcess($arguments);
-        $process->setTty($this->useTty);
 
         $this->output?->note('Executing Biome.js "ci" (pass -v to see more details).');
         if ($this->output?->isVerbose()) {

--- a/src/BiomeJsBinary.php
+++ b/src/BiomeJsBinary.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Process\Process;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class BiomeJsBinary
+final class BiomeJsBinary implements BiomeJsBinaryInterface
 {
     private ?SymfonyStyle $output = null;
     private HttpClientInterface $httpClient;
@@ -41,7 +41,12 @@ final class BiomeJsBinary
             $this->downloadExecutable();
         }
 
-        return new Process([$binary, ...$arguments], $this->cwd);
+        $process = new Process([$binary, ...$arguments], $this->cwd);
+        if ($process->isTtySupported()) {
+            $process->setTty(true);
+        }
+
+        return $process;
     }
 
     private function downloadExecutable(): void

--- a/src/BiomeJsBinaryInterface.php
+++ b/src/BiomeJsBinaryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kocal\BiomeJsBundle;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+
+interface BiomeJsBinaryInterface
+{
+    public function setOutput(?SymfonyStyle $output): void;
+
+    /**
+     * @param array<string> $arguments
+     *
+     * @throws \Exception
+     */
+    public function createProcess(array $arguments = []): Process;
+}

--- a/tests/BiomeJsBinaryTest.php
+++ b/tests/BiomeJsBinaryTest.php
@@ -32,12 +32,12 @@ final class BiomeJsBinaryTest extends TestCase
             $client
         );
         $process = $binary->createProcess(['check', '--apply', '*.{js,ts}']);
-        $this->assertFileExists($binaryDownloadDir . '/fake-version/' . BiomeJsBinary::getBinaryName());
+        self::assertFileExists($binaryDownloadDir . '/fake-version/' . BiomeJsBinary::getBinaryName());
 
         // Windows doesn't wrap arguments in quotes
         $expectedTemplate = '\\' === \DIRECTORY_SEPARATOR ? '"%s" check --apply *.{js,ts}' : "'%s' 'check' '--apply' '*.{js,ts}'";
 
-        $this->assertSame(
+        self::assertSame(
             sprintf($expectedTemplate, $binaryDownloadDir . '/fake-version/' . BiomeJsBinary::getBinaryName()),
             $process->getCommandLine()
         );

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -12,8 +12,10 @@ use Symfony\Component\Filesystem\Filesystem;
 
 final class FunctionalTest extends KernelTestCase
 {
-    protected function setUp(): void
+    public static function setUpBeforeClass(): void
     {
+        parent::setUpBeforeClass();
+
         $fs = new Filesystem();
         if (is_dir($biomejsVarDir = __DIR__ . '/fixtures/var/biomejs')) {
             $fs->remove($biomejsVarDir);

--- a/tests/fixtures/BiomeJsTestKernel.php
+++ b/tests/fixtures/BiomeJsTestKernel.php
@@ -9,6 +9,7 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel;
 
 final class BiomeJsTestKernel extends Kernel
@@ -28,7 +29,11 @@ final class BiomeJsTestKernel extends Kernel
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
-        $container->setParameter('biomejs.use_tty', false);
+        $container->register('biomejs.binary_test', TestBiomeJsBinary::class)
+            ->setDecoratedService('biomejs.binary')
+            ->setArguments([
+                new Reference('biomejs.binary_test.inner'),
+            ]);
 
         $container->loadFromExtension('framework', [
             'secret' => 'foo',

--- a/tests/fixtures/TestBiomeJsBinary.php
+++ b/tests/fixtures/TestBiomeJsBinary.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kocal\BiomeJsBundle\Tests\fixtures;
+
+use Kocal\BiomeJsBundle\BiomeJsBinaryInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+
+final class TestBiomeJsBinary implements BiomeJsBinaryInterface
+{
+    public function __construct(
+        private readonly BiomeJsBinaryInterface $inner,
+    ) {
+    }
+
+    public function setOutput(?SymfonyStyle $output): void
+    {
+        $this->inner->setOutput($output);
+    }
+
+    public function createProcess(array $arguments = []): Process
+    {
+        $arguments[] = '--colors=off';
+
+        $process = $this->inner->createProcess($arguments);
+        // Disable TTY to avoid issues when testing
+        $process->setTty(false);
+
+        return $process;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Close #6   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.),
this will help people understand your PR.
-->
