### PR TITLE
feat(check): deprecate --apply and --apply-unsafe in favor of --write and --unsafe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,13 +116,16 @@ jobs:
       - name: Install Composer dependencies
         run: symfony composer install --prefer-dist --no-interaction --no-progress
 
-      - name: Create a new Symfony project and install kocal/biome-js-bundle
+      - name: Create a new Symfony project
         run: |
           git config --global user.email "hugo@alliau.me"
           git config --global user.name "Hugo Alliaume"
           symfony new my_app --webapp
-          cd my_app
+          
+      - name: Install kocal/biome-js-bundle
+        run: |
           symfony composer config minimum-stability dev
+          symfony composer config --json extra.symfony.allow-contrib 'true'
           symfony composer config repositories.biome-js-bundle '{"type":"path", "url":"../","options":{"symlink":true}}'
           symfony composer require 'kocal/biome-js-bundle:*' --dev --no-interaction
           cat << EOF > biome.json
@@ -137,6 +140,7 @@ jobs:
             }
           }
           EOF
+        working-directory: my_app
 
       - name: Run Biome CI, which should fails
         run: symfony console biomejs:ci .
@@ -144,10 +148,9 @@ jobs:
         working-directory: my_app
 
       - name: Run Biome Check, and apply fixes
-        run: symfony console biomejs:check . --apply
+        run: symfony console biomejs:check . --write
         working-directory: my_app
 
       - name: Run Biome CI, which should now pass
         run: symfony console biomejs:ci .
         working-directory: my_app
-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,32 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\$apply of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:check\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Command/BiomeJsCheckCommand.php
-
-		-
-			message: "#^Parameter \\$applyUnsafe of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:check\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Command/BiomeJsCheckCommand.php
-
-		-
 			message: "#^Parameter \\$changed of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:check\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Command/BiomeJsCheckCommand.php
-
-		-
-			message: "#^Parameter \\$formatterEnabled of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:check\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Command/BiomeJsCheckCommand.php
-
-		-
-			message: "#^Parameter \\$linterEnabled of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:check\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Command/BiomeJsCheckCommand.php
-
-		-
-			message: "#^Parameter \\$organizeImportsEnabled of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:check\\(\\) expects bool, mixed given\\.$#"
 			count: 1
 			path: src/Command/BiomeJsCheckCommand.php
 
@@ -46,22 +21,17 @@ parameters:
 			path: src/Command/BiomeJsCheckCommand.php
 
 		-
+			message: "#^Parameter \\$unsafe of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:check\\(\\) expects bool, mixed given\\.$#"
+			count: 1
+			path: src/Command/BiomeJsCheckCommand.php
+
+		-
+			message: "#^Parameter \\$write of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:check\\(\\) expects bool, mixed given\\.$#"
+			count: 1
+			path: src/Command/BiomeJsCheckCommand.php
+
+		-
 			message: "#^Parameter \\$changed of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:ci\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Command/BiomeJsCiCommand.php
-
-		-
-			message: "#^Parameter \\$formatterEnabled of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:ci\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Command/BiomeJsCiCommand.php
-
-		-
-			message: "#^Parameter \\$linterEnabled of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:ci\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: src/Command/BiomeJsCiCommand.php
-
-		-
-			message: "#^Parameter \\$organizeImportsEnabled of method Kocal\\\\BiomeJsBundle\\\\BiomeJs\\:\\:ci\\(\\) expects bool, mixed given\\.$#"
 			count: 1
 			path: src/Command/BiomeJsCiCommand.php
 
@@ -79,6 +49,7 @@ parameters:
 			message: "#^Cannot call method end\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
 			count: 1
 			path: src/DependencyInjection/BiomeJsExtension.php
+			
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:end\\(\\)\\.$#"
 			count: 1

--- a/src/BiomeJs.php
+++ b/src/BiomeJs.php
@@ -7,6 +7,9 @@ namespace Kocal\BiomeJsBundle;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Process;
 
+/**
+ * @internal
+ */
 final class BiomeJs
 {
     private ?SymfonyStyle $output;
@@ -25,8 +28,8 @@ final class BiomeJs
      * @param array<string> $path
      */
     public function check(
-        bool $apply,
-        bool $applyUnsafe,
+        bool $write,
+        bool $unsafe,
         bool $formatterEnabled,
         bool $linterEnabled,
         bool $organizeImportsEnabled,
@@ -36,11 +39,11 @@ final class BiomeJs
         array $path,
     ): Process {
         $arguments = [];
-        if ($apply) {
-            $arguments[] = '--apply';
+        if ($write) {
+            $arguments[] = '--write';
         }
-        if ($applyUnsafe) {
-            $arguments[] = '--apply-unsafe';
+        if ($unsafe) {
+            $arguments[] = '--unsafe';
         }
         $arguments[] = '--formatter-enabled=' . ($formatterEnabled ? 'true' : 'false');
         $arguments[] = '--linter-enabled=' . ($linterEnabled ? 'true' : 'false');

--- a/src/BiomeJsBinary.php
+++ b/src/BiomeJsBinary.php
@@ -9,6 +9,9 @@ use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Process\Process;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+/**
+ * @internal
+ */
 final class BiomeJsBinary implements BiomeJsBinaryInterface
 {
     private ?SymfonyStyle $output = null;

--- a/src/Command/BiomeJsCheckCommand.php
+++ b/src/Command/BiomeJsCheckCommand.php
@@ -30,8 +30,12 @@ final class BiomeJsCheckCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('apply', null, InputOption::VALUE_NONE, 'Apply safe fixes, formatting and import sorting')
-            ->addOption('apply-unsafe', null, InputOption::VALUE_NONE, 'Apply safe fixes and unsafe fixes, formatting and import sorting')
+            ->addOption('write', null, InputOption::VALUE_NONE, 'Writes safe fixes, formatting and import sorting')
+            ->addOption('unsafe', null, InputOption::VALUE_NONE, ' Allow to do unsafe fixes, should be used with --write')
+            // TODO: Deprecated, remove in favor of --write
+            ->addOption('apply', null, InputOption::VALUE_NONE, 'Apply safe fixes, formatting and import sorting (deprecated, use --write)')
+            // TODO: Deprecated, remove in favor of --unsafe
+            ->addOption('apply-unsafe', null, InputOption::VALUE_NONE, 'Apply safe fixes and unsafe fixes, formatting and import sorting (deprecated, use --write --unsafe)')
             ->addOption('formatter-enabled', null, InputOption::VALUE_OPTIONAL, 'Allow to enable or disable the formatter check', true)
             ->addOption('linter-enabled', null, InputOption::VALUE_OPTIONAL, 'Allow to enable or disable the linter check', true)
             ->addOption('organize-imports-enabled', null, InputOption::VALUE_OPTIONAL, 'Allow to enable or disable the organize imports.', true)
@@ -50,9 +54,23 @@ final class BiomeJsCheckCommand extends Command
     {
         $this->biomeJs->setOutput($this->io);
 
+        $write = $input->getOption('write');
+        $unsafe = $input->getOption('unsafe');
+
+        if ($input->getOption('apply')) {
+            $this->io->warning('The "--apply" option is deprecated and will be removed in the next major version, use "--write" instead.');
+            $write = true;
+        }
+
+        if ($input->getOption('apply-unsafe')) {
+            $this->io->warning('The "--apply-unsafe" option is deprecated and will be removed in the next major version, use "--write --unsafe" instead.');
+            $write = true;
+            $unsafe = true;
+        }
+
         $process = $this->biomeJs->check(
-            apply: $input->getOption('apply'),
-            applyUnsafe: $input->getOption('apply-unsafe'),
+            write: $write,
+            unsafe: $unsafe,
             formatterEnabled: filter_var($input->getOption('formatter-enabled'), FILTER_VALIDATE_BOOL),
             linterEnabled: filter_var($input->getOption('linter-enabled'), FILTER_VALIDATE_BOOL),
             organizeImportsEnabled: filter_var($input->getOption('organize-imports-enabled'), FILTER_VALIDATE_BOOL),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Close #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.),
this will help people understand your PR.
-->

Biome.js recently deprecated `--apply` and `--apply-unsafe` in favor of `--write` and `--unsafe`, so we must do the same: 

```
➜  hugo.alliau.me git:(main) sf console biomejs:check . --apply               

 ! [NOTE] Executing Biome.js "check" (pass -v to see more details).                                                     

internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ⚠ The argument --apply is deprecated, it will be removed in the next major release. Use --write instead.
  

Checked 8 files in 41ms. No fixes applied.
```

```
➜  hugo.alliau.me git:(main) sf console biomejs:check . --apply-unsafe

 ! [NOTE] Executing Biome.js "check" (pass -v to see more details).                                                     

internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ⚠ The argument --apply-unsafe is deprecated, it will be removed in the next major release. Use --write --unsafe instead.
  

Checked 8 files in 44ms. No fixes applied.
```