### PR TITLE
Get rid of deprecations

### DIFF
--- a/src/Command/BiomeJsCheckCommand.php
+++ b/src/Command/BiomeJsCheckCommand.php
@@ -45,7 +45,7 @@ final class BiomeJsCheckCommand extends Command
             ->addArgument('path', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Single file, single path or list of paths');
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->io = new SymfonyStyle($input, $output);
     }

--- a/src/Command/BiomeJsCiCommand.php
+++ b/src/Command/BiomeJsCiCommand.php
@@ -39,7 +39,7 @@ final class BiomeJsCiCommand extends Command
         ;
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->io = new SymfonyStyle($input, $output);
     }

--- a/src/DependencyInjection/BiomeJsExtension.php
+++ b/src/DependencyInjection/BiomeJsExtension.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Loader;
 
 final class BiomeJsExtension extends Extension implements ConfigurationInterface
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\PhpFileLoader($container, new FileLocator(__DIR__ . '/../../config'));
         $loader->load('services.php');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tests pass?   | yes
| Fixed tickets | N/A

Hi, this PR fixes the following deprecations I get:

*  Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Kocal\BiomeJsBundle\DependencyInjection\BiomeJsExtension" now to avoid errors or add an explicit @return annotation to suppress this message. 
*  Method "Symfony\Component\Console\Command\Command::initialize()" might add "void" as a native return type declaration in the future. Do the same in child class "Kocal\BiomeJsBundle\Command\BiomeJsCiCommand" now to avoid errors or add an explicit @return annotation to suppress this message. 
*  Method "Symfony\Component\Console\Command\Command::initialize()" might add "void" as a native return type declaration in the future. Do the same in child class "Kocal\BiomeJsBundle\Command\BiomeJsCheckCommand" now to avoid errors or add an explicit @return annotation to suppress this message. 