### PR TITLE
Add phpstan-baseline.neon to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,5 @@
 .gitignore export-ignore
 ecs.php export-ignore
 phpstan.neon.dist export-ignore
+phpstan-baseline.neon
 phpunit.xml.dist export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tests pass?   | yes
| Fixed tickets | N/A

Add phpstan-baseline.neon to .gitattributes so it's not downloaded by composer anymore :) 
