### PR TITLE
feat: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ when@dev:
             "!var/*",
             "!vendor/*",
             "!composer.json",
-            "!package.json"
+            "!package*.json"
         ]
     }
 }
@@ -84,7 +84,7 @@ In you use Biome.js <2.0.0, you can use the following configuration instead:
             "var/*",
             "vendor/*",
             "composer.json",
-            "package.json"
+            "package*.json"
         ]
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Tests pass?   | n/a
| Fixed tickets | n/a

This PR updates biome.json examples in readme to ignore `package*.json` files by default.
Previous version was formatting/linting `package-lock.json`.
