### PR TITLE
Fix .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,5 @@
 .gitignore export-ignore
 ecs.php export-ignore
 phpstan.neon.dist export-ignore
-phpstan-baseline.neon
+phpstan-baseline.neon export-ignore
 phpunit.xml.dist export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes?
| New feature?  | no
| Fixed tickets | N/A

Seems I forgot to add `export-ignore` when adding PHPStan baseline to .gitattributes 😅 